### PR TITLE
Fix Log File detection

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogFileManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogFileManager.m
@@ -53,7 +53,7 @@ static NSString * const kLogSuffix = @"_log";
 }
 
 - (BOOL)isLogFile:(NSString *)fileName {
-    if (fileName && [fileName isEqualToString:[NSString stringWithFormat:@"%@%@", self.componentName, kLogSuffix]]) {
+    if (fileName && [fileName hasPrefix:[NSString stringWithFormat:@"%@%@", self.componentName, kLogSuffix]]) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
-  CocoaLumberjack appends an integer to the end of log files after archiving previous ones on iOS devices. We need to check that the file has a prefix of componentName_log not an exact match.